### PR TITLE
fix: enforce fixed-width Tag33 checksum in generate/verify

### DIFF
--- a/module/index.mjs
+++ b/module/index.mjs
@@ -19,6 +19,10 @@ export function toBase33(num) {
   return result || "1"; // Return '1' if input is zero
 }
 
+export function toTwoCharBase33(num) {
+  return toBase33(num).padStart(2, "1");
+}
+
 export function calculateBase33Sum(id) {
   let sum = 0;
 
@@ -34,15 +38,19 @@ export const generate = () => {
   const nanoid = customAlphabet(alphabet, 12);
   const baseId = nanoid();
   const sum = calculateBase33Sum(baseId);
-  const b33Sum = toBase33(sum);
+  const b33Sum = toTwoCharBase33(sum);
 
   return baseId + b33Sum;
 };
 
 export const verify = (tag) => {
+  if (!/^[1-9A-HJ-NP-Z]{14}$/.test(tag)) {
+    return false;
+  }
+
   const baseId = tag.slice(0, -2);
   const sum = calculateBase33Sum(baseId);
   const b33Sum = tag.slice(-2);
 
-  return toBase33(sum) === b33Sum;
+  return toTwoCharBase33(sum) === b33Sum;
 };

--- a/module/index.spec.mjs
+++ b/module/index.spec.mjs
@@ -11,3 +11,12 @@ console.log("it should return false for an invalid tag");
 const invalidTag = "1234556789011DD";
 const result2 = tag33.verify(invalidTag);
 assert(result2 === false);
+
+console.log("it should support low checksums as two characters");
+const baseId = "111111111111";
+const lowChecksumTag = baseId + tag33.toTwoCharBase33(tag33.calculateBase33Sum(baseId));
+const result3 = tag33.verify(lowChecksumTag);
+assert(result3 === true);
+
+console.log("it should reject invalid length");
+assert(tag33.verify("111111111111C") === false);


### PR DESCRIPTION
## Summary
- normalize generated checksums to a fixed 2-character width with left padding
- harden `verify` by rejecting tags that do not match the expected 14-char Tag33 format
- add test coverage for low checksum values and invalid-length tags

## Why
`generate` previously appended a variable-width checksum (`toBase33(sum)`), which could produce 1-character checksums for low sums. `verify` always sliced the last 2 chars, causing valid low-sum tags to fail verification.

## Validation
```bash
cd module
npm test
```

Output:
- all assertions passed in `index.spec.mjs`
