### PR TITLE
fix(ci): run tag33 unit tests from module directory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,12 +10,14 @@ jobs:
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: module
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Test using Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - run: cd module
       - run: npm install
       - run: npm test


### PR DESCRIPTION
## Summary
- fix CI test workflow so test commands run from `module/`
- update checkout/setup-node actions to current major versions

## Root cause
The workflow had `cd module` in its own step. In GitHub Actions, each `run` step starts a new shell, so later steps were still executing from repo root.

## Changes
- add `defaults.run.working-directory: module`
- upgrade:
  - `actions/checkout@v4`
  - `actions/setup-node@v4`

## Validation
- local module tests still pass with:
  - `npm test` (from `module/`)

*🐦‍⬛ Co-authored with Gravious.*
