### PR TITLE
fix(ci): clean up GitHub Pages deploy workflow for Vite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,24 +40,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
+          cache: npm
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-        with:
-          # Automatically inject pathPrefix in your Gatsby configuration file.
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: gatsby
-      - name: Restore cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            public
-            .cache
-          key: ${{ runner.os }}-gatsby-build-${{ hashFiles('public') }}
-          restore-keys: |
-            ${{ runner.os }}-gatsby-build-
       - name: Install dependencies
         run: npm install
       - name: Build with Vite


### PR DESCRIPTION
## Summary
- use `cache: npm` in the Pages deploy workflow's Node setup
- remove stale Gatsby-specific generator/cache config from deploy workflow

## Why
The workflow referenced an undefined `steps.detect-package-manager.outputs.manager` value and still carried Gatsby-specific config despite this being a Vite project. This made CI harder to trust and potentially brittle.

## Testing
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each{|f| YAML.load_file(f); puts "OK #{f}" }'`
- `npm ci`
- `npm run build`
